### PR TITLE
Update callbacks on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,7 @@ Example:
 ## Quirks:
 
 - __Android__: The plugin is not native but a simple call to javascript that just working well.
-
+- __iOS__: The plugin calls success() when URL or app is opened, and error() in the following cases:
+	- URL is blank
+	- Custom URL is not available
+	- User cancels opening of custom URL

--- a/ios/OpenUrlExt.m
+++ b/ios/OpenUrlExt.m
@@ -6,19 +6,42 @@
 
 @implementation OpenUrlExt
 
+
+-(void)launchUrl:(NSString*)urlString CDVcommand:(CDVInvokedUrlCommand*)command {
+    NSURL *url = [NSURL URLWithString:urlString];
+    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success){
+        CDVPluginResult* pluginResult;
+        if (success) {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                             messageAsString:[NSString stringWithFormat:@"Success: %@ opened",urlString]];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        } else {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                             messageAsString:[NSString stringWithFormat:@"Failure: %@ not opened",urlString]];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }
+    }];
+}
+
 - (void)open:(CDVInvokedUrlCommand*)command
 {
-    CDVPluginResult* pluginResult = nil;
-    NSString *url = [command.arguments objectAtIndex:0];
+    NSString *urlString = [command.arguments objectAtIndex:0];
 
-    if (url != nil && [url length] > 0) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];            
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:url];
+    if (urlString != nil && [urlString length] > 0) {
+        NSURL *url = [NSURL URLWithString:urlString];
+//        bool canOpen = [[UIApplication sharedApplication] canOpenURL:url];
+//        if (canOpen) {
+            [self launchUrl:urlString CDVcommand:command];
+//        } else {
+//            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+//                                                              messageAsString:[NSString stringWithFormat:@"Failure: %@ not available",urlString]];
+//            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+//        }
     } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                         messageAsString:@"No URL given"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }
-
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 @end

--- a/ios/OpenUrlExt.m
+++ b/ios/OpenUrlExt.m
@@ -28,15 +28,7 @@
     NSString *urlString = [command.arguments objectAtIndex:0];
 
     if (urlString != nil && [urlString length] > 0) {
-        NSURL *url = [NSURL URLWithString:urlString];
-//        bool canOpen = [[UIApplication sharedApplication] canOpenURL:url];
-//        if (canOpen) {
-            [self launchUrl:urlString CDVcommand:command];
-//        } else {
-//            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-//                                                              messageAsString:[NSString stringWithFormat:@"Failure: %@ not available",urlString]];
-//            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-//        }
+        [self launchUrl:urlString CDVcommand:command];
     } else {
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                          messageAsString:@"No URL given"];


### PR DESCRIPTION
The update I had created for iOS gives slightly more robust **onSuccess()** and **onError()** callbacks. **onSuccess()** is only called after the following have occurred:
* The URL is valid
* The URL is opened
     * If the URL is a custom app URL, user is prompted prior to first open. **onSuccess()** is not called until after 'Open' is tapped.

**onError()** is only called if the following occur:
* The URL is blank
* A custom app URL does not refer to an app currently installed on the device
* Opening the custom app URL was denied.
     * If the URL is a custom app URL, user is prompted prior to first open. **onError()** is not called until after this is cancelled.