### PR TITLE
Fixed windows param type

### DIFF
--- a/windows/OpenUrlExtProxy.js
+++ b/windows/OpenUrlExtProxy.js
@@ -1,6 +1,7 @@
 cordova.commandProxy.add("OpenUrlExt", {
 	open: function (successCallback, errorCallback, params) {
-		Windows.System.Launcher.launchUriAsync(params[0]).done(
+		var uri = new Windows.Foundation.Uri(params[0]);
+		Windows.System.Launcher.launchUriAsync(uri).done(
         function (success) {
             if (success) { 
             	console.log("page opened correctly"); 


### PR DESCRIPTION
`launchUriAsync` requires a `Uri` argument

**ref**: https://docs.microsoft.com/en-us/uwp/api/windows.system.launcher